### PR TITLE
Enable mid-line observations

### DIFF
--- a/R/geom_humap.R
+++ b/R/geom_humap.R
@@ -4,6 +4,8 @@ GeomHumap <- ggplot2::ggproto("GeomHumap", Geom,
      draw_key = function (data, ...) draw_key_polygon(data, ...),
      draw_group = function(data, panel_scales, coord, ...) {
          # Transform data and append a label column to the data frame
+         if (h_env$controls$mid_include)
+             data <- dplyr::mutate(data, y = y / 2, count = count / 2)
          coords <- coord$transform(data, panel_scales)
          data$label <- panel_scales$x.labels[data$x]
          data <- dplyr::filter(data, !is.na(label))
@@ -126,14 +128,12 @@ GeomHumap <- ggplot2::ggproto("GeomHumap", Geom,
      }
 )
 
-geom_humap <- function(mapping = NULL, data = NULL, stat = "sum", # stat = "count" (right?)
+geom_humap <- function(mapping = NULL, data = NULL, stat = "count",
                        position = "identity", na.rm = FALSE, show.legend = NA,
                        inherit.aes = TRUE, ...) {
-
     ggplot2::layer(
         geom = GeomHumap, mapping = mapping, data = data, stat = stat,
         position = position, show.legend = show.legend, inherit.aes = inherit.aes,
         params = list(na.rm = na.rm, ...)
     )
-    # remove h_env here?
 }

--- a/R/housekeeping.R
+++ b/R/housekeeping.R
@@ -37,8 +37,7 @@ housekeeping <- function(user, defs) {
     # Set necessary defaults, if none given by user
     h_env$controls$na_fill <- h_env$controls$na_fill %||% "#000000"
     h_env$controls$outline_colour <- h_env$controls$outline_colour %||% "#343434"
-    # h_env$controls$mid_include <- h_env$controls$mid_include %||% FALSE
-    h_env$controls$mid_include <- FALSE
+    h_env$controls$mid_include <- h_env$controls$mid_include %||% FALSE
     # controls$vert_adj needs bounding box of map, so defined in prep_annotations.R
     if (h_env$body_halves %in% c("right", "left")) h_env$body_halves <- "join"
         # I'm disabling this whole half business, people need to give useful data

--- a/R/make_label.R
+++ b/R/make_label.R
@@ -15,8 +15,7 @@ make_label <- function (id, data, local_coords) {
     tid <- if (!h_env$body_halves == "join") id else substring(id, regexpr("_", id) + 1)
 
     # Base label with absolute and relative frequencies
-    label <- sprintf("%s (%s%%)",
-                     data[data$label == tid, "count"] / (if (h_env$controls$mid_include) 2 else 1),
+    label <- sprintf("%s (%s%%)", data[data$label == tid, "count"],
                      round(data[data$label == tid, "prop"] * 100, 0))
 
     # If desired by user, expand label to include also name of region


### PR DESCRIPTION
With this setup, mid-line observations count as 0.5 observation on each side. UseRs will need to set `labels = function(.) ./2` inside `scale_fill_continuous()` if they choose to show the fill legend. This is due to an inelegant "hack" to have ggplot2 divide the observation. See file [generate_mapped_loc.R](https://github.com/benskov/humapr/blob/enable_midline/R/generate_mapped_loc.R)